### PR TITLE
[feat] Add Competition Room View

### DIFF
--- a/Git-Challenges/Git-Challenges.xcodeproj/project.pbxproj
+++ b/Git-Challenges/Git-Challenges.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		73EDBD71279A815300C9B6F0 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73EDBD70279A815300C9B6F0 /* LoginViewModel.swift */; };
 		73F4691C279FD0A300991E71 /* WriteLogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F4691B279FD0A300991E71 /* WriteLogs.swift */; };
 		A83AA0E327992E870006A718 /* Indicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83AA0E227992E870006A718 /* Indicator.swift */; };
-		A83AA0E527992EA10006A718 /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83AA0E427992EA10006A718 /* ProgressBar.swift */; };
+		A83AA0E527992EA10006A718 /* ProgressBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83AA0E427992EA10006A718 /* ProgressBarModifier.swift */; };
 		A83AA0E7279932890006A718 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83AA0E6279932890006A718 /* Date+Extensions.swift */; };
 		A83AA0E9279935BF0006A718 /* Texts.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83AA0E8279935BF0006A718 /* Texts.swift */; };
 		A83AA0EF2799857F0006A718 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83AA0EE2799857F0006A718 /* SettingView.swift */; };
@@ -87,6 +87,9 @@
 		A896B0FB27B4ECF1005D9669 /* SettingCellModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A896B0FA27B4ECF1005D9669 /* SettingCellModifier.swift */; };
 		A8A113352793F95F00F9C984 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A113342793F95F00F9C984 /* Constants.swift */; };
 		A8E51E882795378600B4F08A /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E51E872795378600B4F08A /* Color+Extensions.swift */; };
+		A8E9B2AC27C612EF006403E2 /* CompetitionRoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E9B2AB27C612EF006403E2 /* CompetitionRoomView.swift */; };
+		A8E9B2AE27C620B5006403E2 /* NavigationBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E9B2AD27C620B5006403E2 /* NavigationBarModifier.swift */; };
+		A8E9B2B027C657B8006403E2 /* CompetitionRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E9B2AF27C657B8006403E2 /* CompetitionRoomViewModel.swift */; };
 		A8F8233927929C920000FB08 /* ChallengeCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F8233827929C920000FB08 /* ChallengeCardView.swift */; };
 		A8F8233D27929DCB0000FB08 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F8233C27929DCB0000FB08 /* MainView.swift */; };
 /* End PBXBuildFile section */
@@ -162,7 +165,7 @@
 		73EDBD70279A815300C9B6F0 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		73F4691B279FD0A300991E71 /* WriteLogs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteLogs.swift; sourceTree = "<group>"; };
 		A83AA0E227992E870006A718 /* Indicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Indicator.swift; sourceTree = "<group>"; };
-		A83AA0E427992EA10006A718 /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
+		A83AA0E427992EA10006A718 /* ProgressBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBarModifier.swift; sourceTree = "<group>"; };
 		A83AA0E6279932890006A718 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		A83AA0E8279935BF0006A718 /* Texts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Texts.swift; sourceTree = "<group>"; };
 		A83AA0EE2799857F0006A718 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
@@ -179,6 +182,9 @@
 		A896B0FA27B4ECF1005D9669 /* SettingCellModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingCellModifier.swift; sourceTree = "<group>"; };
 		A8A113342793F95F00F9C984 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		A8E51E872795378600B4F08A /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
+		A8E9B2AB27C612EF006403E2 /* CompetitionRoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompetitionRoomView.swift; sourceTree = "<group>"; };
+		A8E9B2AD27C620B5006403E2 /* NavigationBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifier.swift; sourceTree = "<group>"; };
+		A8E9B2AF27C657B8006403E2 /* CompetitionRoomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompetitionRoomViewModel.swift; sourceTree = "<group>"; };
 		A8F8233827929C920000FB08 /* ChallengeCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeCardView.swift; sourceTree = "<group>"; };
 		A8F8233C27929DCB0000FB08 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -250,6 +256,7 @@
 				73E1A83E27993C8400E1BDFE /* BadgeView.swift */,
 				73528DF727997183005DF67C /* LoginView.swift */,
 				A83AA0EE2799857F0006A718 /* SettingView.swift */,
+				A8E9B2AB27C612EF006403E2 /* CompetitionRoomView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -354,6 +361,7 @@
 				73E1A84027993CB500E1BDFE /* BadgeViewModel.swift */,
 				73E33FA82796C35300BF994D /* NameCardViewModel.swift */,
 				73EDBD70279A815300C9B6F0 /* LoginViewModel.swift */,
+				A8E9B2AF27C657B8006403E2 /* CompetitionRoomViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -364,8 +372,9 @@
 				A896B0FA27B4ECF1005D9669 /* SettingCellModifier.swift */,
 				73710DAB279018A6009EBA62 /* CardModifier.swift */,
 				A83AA0E227992E870006A718 /* Indicator.swift */,
-				A83AA0E427992EA10006A718 /* ProgressBar.swift */,
+				A83AA0E427992EA10006A718 /* ProgressBarModifier.swift */,
 				A83AA0E8279935BF0006A718 /* Texts.swift */,
+				A8E9B2AD27C620B5006403E2 /* NavigationBarModifier.swift */,
 			);
 			path = Modifier;
 			sourceTree = "<group>";
@@ -515,6 +524,7 @@
 				73CF60A727900339005F4BF4 /* ViewController.swift in Sources */,
 				A83E07F927971B8500BFB1A0 /* Progress.swift in Sources */,
 				73ED634627C35EA7002CAD9C /* CompetitionService.swift in Sources */,
+				A8E9B2AE27C620B5006403E2 /* NavigationBarModifier.swift in Sources */,
 				73E1A84327994DC800E1BDFE /* Badge.swift in Sources */,
 				A83AA0E327992E870006A718 /* Indicator.swift in Sources */,
 				73E1A83F27993C8400E1BDFE /* BadgeView.swift in Sources */,
@@ -537,6 +547,7 @@
 				A8A113352793F95F00F9C984 /* Constants.swift in Sources */,
 				A8F8233927929C920000FB08 /* ChallengeCardView.swift in Sources */,
 				A896B0F527B4EC6A005D9669 /* NotificationCell.swift in Sources */,
+				A8E9B2B027C657B8006403E2 /* CompetitionRoomViewModel.swift in Sources */,
 				730952C627C4BFA6007A1155 /* RandomNumberGenarator.swift in Sources */,
 				73F4691C279FD0A300991E71 /* WriteLogs.swift in Sources */,
 				730952C027C4BE82007A1155 /* JoinRoomModalView.swift in Sources */,
@@ -544,11 +555,12 @@
 				73B7CBEB27BA7138006FB99C /* CompetitionMainView.swift in Sources */,
 				731FF2A82796B296001CD5E7 /* Theme.swift in Sources */,
 				73B7CBE927BA6DEB006FB99C /* MainTabView.swift in Sources */,
+				A8E9B2AC27C612EF006403E2 /* CompetitionRoomView.swift in Sources */,
 				73E7F07A27927B9D0045AC5F /* String+Extensions.swift in Sources */,
 				730952BD27C47466007A1155 /* RoomData.swift in Sources */,
 				730952C427C4BF66007A1155 /* Encodable+Extension.swift in Sources */,
 				73528DF827997183005DF67C /* LoginView.swift in Sources */,
-				A83AA0E527992EA10006A718 /* ProgressBar.swift in Sources */,
+				A83AA0E527992EA10006A718 /* ProgressBarModifier.swift in Sources */,
 				73CF60A527900339005F4BF4 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Git-Challenges/Git-Challenges.xcodeproj/project.pbxproj
+++ b/Git-Challenges/Git-Challenges.xcodeproj/project.pbxproj
@@ -816,7 +816,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = StaticWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2.0;
+				CURRENT_PROJECT_VERSION = 3.0;
 				DEVELOPMENT_TEAM = 9TH57H8UP9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LetsWidget/Info.plist;
@@ -828,7 +828,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.Caterpie.LetsWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -845,7 +845,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = StaticWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2.0;
+				CURRENT_PROJECT_VERSION = 3.0;
 				DEVELOPMENT_TEAM = 9TH57H8UP9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LetsWidget/Info.plist;
@@ -857,7 +857,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.Caterpie.LetsWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Git-Challenges/Git-Challenges.xcodeproj/project.pbxproj
+++ b/Git-Challenges/Git-Challenges.xcodeproj/project.pbxproj
@@ -746,7 +746,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = "Let's Git it!/Let's Git it!.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2.0;
+				CURRENT_PROJECT_VERSION = 3.0;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = 9TH57H8UP9;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -764,7 +764,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.Caterpie;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -782,7 +782,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = "Let's Git it!/Let's Git it!.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2.0;
+				CURRENT_PROJECT_VERSION = 3.0;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = 9TH57H8UP9;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -800,7 +800,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.Caterpie;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Git-Challenges/Let's Git it!/ModalView/CreateRoomModalView.swift
+++ b/Git-Challenges/Let's Git it!/ModalView/CreateRoomModalView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct CreateRoomModalView: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
-    @EnvironmentObject var competitionMainViewModel: CompetitionService
+    @EnvironmentObject var competitionService: CompetitionService
     @State var title: String = ""
     @State var startDate: Date = Date()
     @State var maxParticipants: Int = 2
@@ -62,7 +62,7 @@ struct CreateRoomModalView: View {
                                                       startDate: startDate,
                                                       goal: goal,
                                                       maxParticipants: maxParticipants)
-                    competitionMainViewModel.createRoom(with: roomData)
+                    competitionService.createRoom(with: roomData)
                     self.presentationMode.wrappedValue.dismiss()
                 } label: {
                     Text("Save")

--- a/Git-Challenges/Let's Git it!/Model/roomData.swift
+++ b/Git-Challenges/Let's Git it!/Model/roomData.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-struct RoomData: Codable, Equatable {
+struct RoomData: Codable {
     var id: String
     var title: String
     var startDate: String

--- a/Git-Challenges/Let's Git it!/Model/roomData.swift
+++ b/Git-Challenges/Let's Git it!/Model/roomData.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-struct RoomData: Codable {
+struct RoomData: Codable, Equatable {
     var id: String
     var title: String
     var startDate: String

--- a/Git-Challenges/Let's Git it!/Model/roomData.swift
+++ b/Git-Challenges/Let's Git it!/Model/roomData.swift
@@ -13,14 +13,26 @@ struct RoomData: Codable {
     var startDate: String
     var goal: Int
     var participants: [String]
+    var kickedUsers: [String]
     var maxParticipants: Int
+    
+    init() {
+        self.id = ""
+        self.title = ""
+        self.startDate = ""
+        self.goal = 0
+        self.participants = [String]()
+        self.kickedUsers = [String]()
+        self.maxParticipants = 0
+    }
     
     init (title: String, startDate: Date, goal: String, maxParticipants: Int) {
         self.id = ""
         self.title = title
         self.startDate = startDate.toString
         self.goal = Int(goal) ?? 10
-        self.participants = []
+        self.participants = [String]()
+        self.kickedUsers = [String]()
         self.maxParticipants = maxParticipants
     }
     
@@ -30,6 +42,7 @@ struct RoomData: Codable {
         self.startDate = startDate
         self.goal = goal
         self.participants = participants
+        self.kickedUsers = [String]()
         self.maxParticipants = maxParticipants
     }
 }

--- a/Git-Challenges/Let's Git it!/Modifier/NavigationBarModifier.swift
+++ b/Git-Challenges/Let's Git it!/Modifier/NavigationBarModifier.swift
@@ -1,0 +1,27 @@
+//
+//  NavigationBarModifier.swift
+//  Let's Git it!
+//
+//  Created by 권은빈 on 2022/02/23.
+//
+
+import SwiftUI
+
+// TODO: Navigation Link로 넘어갔을 때 Back 버튼 삭제 -> custom back button
+
+struct NavigationBarModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 14.0, *) {
+            content
+                .navigationTitle("")
+                .navigationBarTitleDisplayMode(.inline)
+                .navigationBarHidden(true)
+                .ignoresSafeArea(.keyboard)
+        }
+        else {
+            content
+                .navigationBarHidden(true)
+                .navigationBarTitle("")
+        }
+    }
+}

--- a/Git-Challenges/Let's Git it!/Modifier/ProgressBarModifier.swift
+++ b/Git-Challenges/Let's Git it!/Modifier/ProgressBarModifier.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ProgressBar: ViewModifier {
+struct ProgressBarModifier: ViewModifier {
     
     let size: CGSize
     let color: Color

--- a/Git-Challenges/Let's Git it!/Service/CompetitionService.swift
+++ b/Git-Challenges/Let's Git it!/Service/CompetitionService.swift
@@ -57,6 +57,7 @@ class CompetitionService: ObservableObject {
     }
     
     // TODO: kickedUsers에서 userName 탐색 로직 추가
+    // MARK: roomNumber 입력 않고 join 버튼 누르면 'Document path cannot be empty" 런타임 에러 발생
     func joinRoom(_ roomNumber: String) {
         isValidRoomIDtoJoin(id: roomNumber) { isDone, errString in
             if isDone == false {
@@ -104,6 +105,7 @@ class CompetitionService: ObservableObject {
     
     func update() {
         var updatedRoomDatas: [RoomData] = [RoomData]()
+        roomDatas.removeAll()
         
         db.collection("RoomData").whereField("participants", arrayContains: userID)
             .addSnapshotListener { querySnapshot, error in
@@ -125,6 +127,7 @@ class CompetitionService: ObservableObject {
                     }
                     updatedRoomDatas.append(roomData)
                 }
+
                 self.roomDatas = updatedRoomDatas
             }
     }

--- a/Git-Challenges/Let's Git it!/Subview/Progress.swift
+++ b/Git-Challenges/Let's Git it!/Subview/Progress.swift
@@ -40,7 +40,7 @@ struct Progress: View {
             ZStack(alignment: .leading) {
                 Capsule()
                     .modifier(
-                        ProgressBar(
+                        ProgressBarModifier(
                             size: CGSize(
                                 width: progressBarSize.width,
                                 height: progressBarSize.height),
@@ -49,7 +49,7 @@ struct Progress: View {
                     )
                 Capsule()
                     .modifier(
-                        ProgressBar(
+                        ProgressBarModifier(
                             size: CGSize(
                                 width: progressBarSize.width * userInfoService.percentage,
                                 height: progressBarSize.height),

--- a/Git-Challenges/Let's Git it!/Util/Constants.swift
+++ b/Git-Challenges/Let's Git it!/Util/Constants.swift
@@ -15,9 +15,20 @@ enum URLString {
     static let appStore: String = "itms-apps://itunes.apple.com/app/1606646308"
     static let appStoreLookUp: String = "https://itunes.apple.com/lookup?bundleId=com.github.Caterpie"
 }
+
 enum Message {
     static let notiDeniedInSettingsTitle: String = "Notification has been disabled for this app"
     static let notiDeniedInSettingsMessage: String = "Please go to settings to enable it now"
+    static let kickUserFromRoomTitle: String = "Kick the user out of this room"
+    static let kickUserFromRoomMessage: String = "This cannot be restored.\nReally want to kick the user?"
+    static let deleteRoomTitle: String = "Delete this room"
+    static let deleteRoomMessage: String = "This cannot be restored.\nReally want to delete the room?"
+}
+
+enum RoomModificationAlertType {
+    case kickUserFromRoom
+    case deleteRoom
+    case noAction
 }
 
 enum widthRatio {

--- a/Git-Challenges/Let's Git it!/View/CompetitionMainView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionMainView.swift
@@ -26,8 +26,7 @@ struct CompetitionMainView: View {
                 }
                 ScrollView {
                     VStack {
-                        ForEach (0..<competitionService.roomDatas.count, id: \.self) { index in
-                            let room = competitionService.roomDatas[index]
+                        ForEach (competitionService.roomDatas, id: \.self.id) { room in
                             NavigationLink {
                                 CompetitionRoomView(of: room.id)
                                     .environmentObject(competitionService)

--- a/Git-Challenges/Let's Git it!/View/CompetitionMainView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionMainView.swift
@@ -10,41 +10,65 @@ import SwiftUI
 struct CompetitionMainView: View {
     @State private var showCreateRoomModal: Bool = false
     @State private var showJoinRoomModal: Bool = false
-    @ObservedObject var competitionMainViewModel = CompetitionService()
+    @ObservedObject var competitionService = CompetitionService()
     
     var body: some View {
-        let roomDatas = competitionMainViewModel.roomDatas
-        
-        VStack {
-            HStack () {
-                Spacer()
-                Button  {
-                    showJoinRoomModal = true
-                } label: {
-                    Text("Join")
-                        .padding()
+//        let roomDatas = competitionService.roomDatas
+        NavigationView {
+            VStack {
+                HStack () {
+                    Spacer()
+                    Button  {
+                        showJoinRoomModal = true
+                    } label: {
+                        Text("Join")
+                            .padding()
+                    }
                 }
-            }
-            ScrollView {
-                VStack {
-                    ForEach (roomDatas, id: \.self.id) { room in
-                        VStack {
-                            Text("Title: \(room.title)")
-                            Text("Start Date: \(room.startDate)")
-                            Text("Goal: \(room.goal)")
-                            
-                            HStack {
-                                Image(systemName: "person.circle.fill")
-                                    .padding([.trailing], -7)
-                                Image(systemName: "person.circle.fill")
-                                    .padding([.horizontal], -7)
-                                Image(systemName: "person.circle.fill")
-                                    .padding([.horizontal], -7)
-                                Image(systemName: "person.circle.fill")
-                                    .padding([.horizontal], -7)
-                                Spacer()
+                ScrollView {
+                    VStack {
+                        ForEach (competitionService.roomDatas, id: \.self.id) { room in
+                            NavigationLink {
+                                CompetitionRoomView(of: room.id)
+                                    .environmentObject(competitionService)
+                            } label: {
+                                VStack {
+                                    Text("Title: \(room.title)")
+                                    Text("Start Date: \(room.startDate)")
+                                    Text("Goal: \(room.goal)")
+                                    
+                                    HStack {
+                                        Image(systemName: "person.circle.fill")
+                                            .padding([.trailing], -7)
+                                        Image(systemName: "person.circle.fill")
+                                            .padding([.horizontal], -7)
+                                        Image(systemName: "person.circle.fill")
+                                            .padding([.horizontal], -7)
+                                        Image(systemName: "person.circle.fill")
+                                            .padding([.horizontal], -7)
+                                        Spacer()
+                                    }
+                                    .padding([.horizontal])
+                                }
+                                .modifier(CardModifier(height: 140))
+                                .background(
+                                    RoundedRectangle(cornerRadius: 20)
+                                        .foregroundColor(ColorPalette.green.0[1])
+                                        .opacity(0.8)
+                                )
+                                .padding([.vertical], 5)
                             }
-                            .padding([.horizontal])
+                        }
+                        .buttonStyle(.plain)
+                        
+                        VStack {
+                            Image(systemName: "plus.circle")
+                                .resizable()
+                                .frame(width: 50, height: 50)
+                            Text("방 만들기")
+                        }
+                        .onTapGesture {
+                            showCreateRoomModal = true
                         }
                         .modifier(CardModifier(height: 140))
                         .background(
@@ -54,34 +78,18 @@ struct CompetitionMainView: View {
                         )
                         .padding([.vertical], 5)
                     }
-                    
-                    VStack {
-                        Image(systemName: "plus.circle")
-                            .resizable()
-                            .frame(width: 50, height: 50)
-                        Text("방 만들기")
-                    }
-                    .onTapGesture {
-                        showCreateRoomModal = true
-                    }
-                    .modifier(CardModifier(height: 140))
-                    .background(
-                        RoundedRectangle(cornerRadius: 20)
-                            .foregroundColor(ColorPalette.green.0[1])
-                            .opacity(0.8)
-                    )
-                    .padding([.vertical], 5)
+                    Spacer()
                 }
-                Spacer()
+                .sheet(isPresented: self.$showCreateRoomModal) {
+                    CreateRoomModalView()
+                        .environmentObject(competitionService)
+                }
+                .sheet(isPresented: self.$showJoinRoomModal) {
+                    JoinRoomModalView()
+                        .environmentObject(competitionService)
+                }
             }
-            .sheet(isPresented: self.$showCreateRoomModal) {
-                CreateRoomModalView()
-                    .environmentObject(competitionMainViewModel)
-            }
-            .sheet(isPresented: self.$showJoinRoomModal) {
-                JoinRoomModalView()
-                    .environmentObject(competitionMainViewModel)
-            }
+            .modifier(NavigationBarModifier())
         }
     }
 }

--- a/Git-Challenges/Let's Git it!/View/CompetitionMainView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionMainView.swift
@@ -13,7 +13,6 @@ struct CompetitionMainView: View {
     @ObservedObject var competitionService = CompetitionService()
     
     var body: some View {
-//        let roomDatas = competitionService.roomDatas
         NavigationView {
             VStack {
                 HStack () {
@@ -27,7 +26,8 @@ struct CompetitionMainView: View {
                 }
                 ScrollView {
                     VStack {
-                        ForEach (competitionService.roomDatas, id: \.self.id) { room in
+                        ForEach (0..<competitionService.roomDatas.count, id: \.self) { index in
+                            let room = competitionService.roomDatas[index]
                             NavigationLink {
                                 CompetitionRoomView(of: room.id)
                                     .environmentObject(competitionService)

--- a/Git-Challenges/Let's Git it!/View/CompetitionRoomView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionRoomView.swift
@@ -1,0 +1,138 @@
+//
+//  CompetitionRoomView.swift
+//  Let's Git it!
+//
+//  Created by 권은빈 on 2022/02/23.
+//
+
+import SwiftUI
+
+struct CompetitionRoomView: View {
+    @Environment(\.presentationMode) private var presentationMode
+    @EnvironmentObject var competitionService: CompetitionService
+    @State private var showAlert: Bool = false
+    @State private var alertType: RoomModificationAlertType = .noAction
+    @State private var userNameToKick: String = ""
+    @State private var roomData: RoomData = RoomData()
+    var roomID: String
+    
+    init(of roomID: String) {
+        self.roomID = roomID
+    }
+    
+    var body: some View {
+        VStack {
+            navigationBar
+            List {
+                ForEach(roomData.participants, id: \.self) { participant in
+                    VStack {
+                        HStack {
+                            Text(participant)
+                            Spacer()
+                            Button {
+                                alertType = .kickUserFromRoom
+                                userNameToKick = participant
+                                showAlert.toggle()
+                            } label: {
+                                Text("Kick")
+                                    .foregroundColor(.red)
+                            }
+                        }
+                        .padding()
+                        .buttonStyle(PlainButtonStyle())
+                        progressBar(width: uiSize.width * 0.7, height: 10, percent: 0.5)
+                            .padding()
+                    }
+                }
+            }
+        }
+        .navigationBarHidden(true)
+        .navigationBarBackButtonHidden(true)
+        .onAppear {
+            CompetitionService.roomData(with: roomID) { roomData in
+                self.roomData = roomData
+            }
+        }
+        .alert(isPresented: $showAlert) {
+            switch alertType {
+            case .kickUserFromRoom:
+                return Alert(
+                    title: Text(Message.kickUserFromRoomTitle),
+                    message: Text(Message.kickUserFromRoomMessage),
+                    primaryButton: .cancel(Text("Kick")) {
+                        competitionService.kickUserFromRoom(
+                            roomID: roomData.id,
+                            userName: userNameToKick
+                        )
+                        CompetitionService.roomData(with: roomData.id) { roomData in
+                            self.roomData = roomData
+                        }
+                    },
+                    secondaryButton: .default(Text("Cancel"))
+                )
+            case .deleteRoom:
+                return Alert(
+                    title: Text(Message.deleteRoomTitle),
+                    message: Text(Message.deleteRoomMessage),
+                    primaryButton: .cancel(Text("Delete")) {
+                        competitionService.deleteRoom(roomID: roomData.id)
+                        presentationMode.wrappedValue.dismiss()
+                    },
+                    secondaryButton: .default(Text("Cancel"))
+                )
+            case .noAction:
+                break
+            }
+            return Alert(title: Text(""), message: Text(""), dismissButton: .cancel())
+        }
+    }
+    
+    private var navigationBar: some View {
+        HStack {
+            Button {
+                presentationMode.wrappedValue.dismiss()
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 21))
+                    Text("Back")
+                }
+            }
+            Spacer(minLength: 0)
+            Text(roomData.title)
+            Spacer(minLength: 0)
+            Button {
+                alertType = .deleteRoom
+                showAlert.toggle()
+            } label: {
+                 Text("Delete")
+                    .foregroundColor(.red)
+            }
+        }
+        .padding()
+    }
+    
+    private func progressBar(width: CGFloat, height: CGFloat, percent: CGFloat) -> some View {
+        ZStack(alignment: .leading) {
+            Capsule()
+                .modifier(
+                    ProgressBarModifier(
+                        size: CGSize(
+                            width: width,
+                            height: height),
+                        color: .gray
+                    )
+                )
+            Capsule()
+                .modifier(
+                    ProgressBarModifier(
+                        size: CGSize(
+                            width: width * percent,
+                            height: height),
+                        color: .green
+                    )
+                )
+        }
+    }
+}
+

--- a/Git-Challenges/Let's Git it!/View/CompetitionRoomView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionRoomView.swift
@@ -75,8 +75,9 @@ struct CompetitionRoomView: View {
                     title: Text(Message.deleteRoomTitle),
                     message: Text(Message.deleteRoomMessage),
                     primaryButton: .cancel(Text("Delete")) {
-                        competitionService.deleteRoom(roomID: roomData.id)
-                        presentationMode.wrappedValue.dismiss()
+                        competitionService.deleteRoom(roomID: roomData.id) {
+                            presentationMode.wrappedValue.dismiss()
+                        }
                     },
                     secondaryButton: .default(Text("Cancel"))
                 )

--- a/Git-Challenges/Let's Git it!/View/MainView.swift
+++ b/Git-Challenges/Let's Git it!/View/MainView.swift
@@ -29,7 +29,7 @@ struct MainView: View {
                 })
                 .environmentObject(userInfoService)
                 .environmentObject(colorThemeService)
-                .modifier(NavigationBar())
+                .modifier(NavigationBarModifier())
             }
         }
         .navigationViewStyle(.stack)
@@ -60,22 +60,5 @@ struct MainView: View {
                 .font(.system(size: 20, weight: .bold))
         }
         .padding([.horizontal])
-    }
-}
-
-struct NavigationBar: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(iOS 14.0, *) {
-            content
-                .navigationTitle("")
-                .navigationBarTitleDisplayMode(.inline)
-                .navigationBarHidden(true)
-                .ignoresSafeArea(.keyboard)
-        }
-        else {
-            content
-                .navigationBarHidden(true)
-                .navigationBarTitle("")
-        }
     }
 }

--- a/Git-Challenges/Let's Git it!/ViewModel/CompetitionRoomViewModel.swift
+++ b/Git-Challenges/Let's Git it!/ViewModel/CompetitionRoomViewModel.swift
@@ -8,14 +8,5 @@
 import SwiftUI
 
 class CompetitionRoomViewModel: ObservableObject {
-    // Users' git streak count and return the values
-//    @Published var roomData: RoomData
-//    var roomID: String
-//    
-//    init(roomID: String) {
-//        self.roomID = roomID
-//        CompetitionService.getRoomData(with: roomID) { roomData in
-//            self.roomData = roomData
-//        }
-//    }
+    // TODO: Users' git streak count and return the values
 }

--- a/Git-Challenges/Let's Git it!/ViewModel/CompetitionRoomViewModel.swift
+++ b/Git-Challenges/Let's Git it!/ViewModel/CompetitionRoomViewModel.swift
@@ -1,0 +1,21 @@
+//
+//  CompetitionRoomViewModel.swift
+//  Let's Git it!
+//
+//  Created by 권은빈 on 2022/02/23.
+//
+
+import SwiftUI
+
+class CompetitionRoomViewModel: ObservableObject {
+    // Users' git streak count and return the values
+//    @Published var roomData: RoomData
+//    var roomID: String
+//    
+//    init(roomID: String) {
+//        self.roomID = roomID
+//        CompetitionService.getRoomData(with: roomID) { roomData in
+//            self.roomData = roomData
+//        }
+//    }
+}


### PR DESCRIPTION
### 반영 사항
- CompetitionRoomView 생성
- 선택된 Room 삭제 기능 추가
- Room의 특정 participant 강퇴 기능 추가
- 이에 따라 RoomData에 kickedUsers 배열 추가 => *추후 joinRoom에 userName이 kicked인지 아닌지 확인하는 로직 필요*
- 데이터 변경시 update하는 함수 추가

### 추후 개발 사항
- participants의 streak count하는 로직 ViewModel로 추가
- 현재 print문으로 처리해놓은 success/fail 부분 alert 추가

### 의문점
roomData.. 이거 뭐죠?
분명히 git add 했는데도 계속 ... 좀비처럼.... 남아있습니다...