### PR TITLE
[feat] Separate Ongoing and Ended Competition Room View #89

### DIFF
--- a/Git-Challenges/Git-Challenges.xcodeproj/project.pbxproj
+++ b/Git-Challenges/Git-Challenges.xcodeproj/project.pbxproj
@@ -87,6 +87,8 @@
 		A896B0F927B4ECDD005D9669 /* VersionCheckCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A896B0F827B4ECDD005D9669 /* VersionCheckCell.swift */; };
 		A896B0FB27B4ECF1005D9669 /* SettingCellModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A896B0FA27B4ECF1005D9669 /* SettingCellModifier.swift */; };
 		A8A113352793F95F00F9C984 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A113342793F95F00F9C984 /* Constants.swift */; };
+		A8AD131227DB44980023E344 /* CompetitionInProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AD131127DB44980023E344 /* CompetitionInProgressView.swift */; };
+		A8AD131427DB45990023E344 /* CompetitionEndedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AD131327DB45990023E344 /* CompetitionEndedView.swift */; };
 		A8E51E882795378600B4F08A /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E51E872795378600B4F08A /* Color+Extensions.swift */; };
 		A8E9B2AC27C612EF006403E2 /* CompetitionRoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E9B2AB27C612EF006403E2 /* CompetitionRoomView.swift */; };
 		A8E9B2AE27C620B5006403E2 /* NavigationBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E9B2AD27C620B5006403E2 /* NavigationBarModifier.swift */; };
@@ -184,6 +186,8 @@
 		A896B0F827B4ECDD005D9669 /* VersionCheckCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionCheckCell.swift; sourceTree = "<group>"; };
 		A896B0FA27B4ECF1005D9669 /* SettingCellModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingCellModifier.swift; sourceTree = "<group>"; };
 		A8A113342793F95F00F9C984 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		A8AD131127DB44980023E344 /* CompetitionInProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompetitionInProgressView.swift; sourceTree = "<group>"; };
+		A8AD131327DB45990023E344 /* CompetitionEndedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompetitionEndedView.swift; sourceTree = "<group>"; };
 		A8E51E872795378600B4F08A /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
 		A8E9B2AB27C612EF006403E2 /* CompetitionRoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompetitionRoomView.swift; sourceTree = "<group>"; };
 		A8E9B2AD27C620B5006403E2 /* NavigationBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifier.swift; sourceTree = "<group>"; };
@@ -262,6 +266,8 @@
 				73528DF727997183005DF67C /* LoginView.swift */,
 				A83AA0EE2799857F0006A718 /* SettingView.swift */,
 				A8E9B2AB27C612EF006403E2 /* CompetitionRoomView.swift */,
+				A8AD131327DB45990023E344 /* CompetitionEndedView.swift */,
+				A8AD131127DB44980023E344 /* CompetitionInProgressView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -519,6 +525,7 @@
 				73E7F07727927A3A0045AC5F /* Commit.swift in Sources */,
 				A83AA0F127998FA80006A718 /* NotificationManager.swift in Sources */,
 				733D9DFE27D9F1780062ECF2 /* KeyboardObserver.swift in Sources */,
+				A8AD131427DB45990023E344 /* CompetitionEndedView.swift in Sources */,
 				A896B0FB27B4ECF1005D9669 /* SettingCellModifier.swift in Sources */,
 				73EDBD71279A815300C9B6F0 /* LoginViewModel.swift in Sources */,
 				73E33FAB2796C36F00BF994D /* NameCard.swift in Sources */,
@@ -547,6 +554,7 @@
 				730952C227C4BEAC007A1155 /* CreateRoomModalView.swift in Sources */,
 				735AA3BE27914950000E4E8C /* ContributionView.swift in Sources */,
 				A83E07F32796F6DC00BFB1A0 /* Goal.swift in Sources */,
+				A8AD131227DB44980023E344 /* CompetitionInProgressView.swift in Sources */,
 				73751ED6279D6A76006A8F94 /* ActivityIndicator.swift in Sources */,
 				A83AA0EF2799857F0006A718 /* SettingView.swift in Sources */,
 				73E33FA92796C35300BF994D /* NameCardViewModel.swift in Sources */,

--- a/Git-Challenges/Let's Git it!/Service/CompetitionService.swift
+++ b/Git-Challenges/Let's Git it!/Service/CompetitionService.swift
@@ -48,13 +48,11 @@ class CompetitionService: ObservableObject {
                                     maxParticipants: roomData.maxParticipants).asDictionary!
             self.db.collection("RoomData").document(roomID).setData(roomData)
             
-            // MARK: Reload Room Datas
+            // Reload Room Datas
             self.requestRoomDatas()
         }
     }
     
-    // TODO: kickedUsers에서 userName 탐색 로직 추가
-    // MARK: roomNumber 입력 않고 join 버튼 누르면 'Document path cannot be empty" 런타임 에러 발생
     func joinRoom(_ roomNumber: String) {
         isValidRoomIDtoJoin(id: roomNumber) { isDone, errString in
             if isDone == false {
@@ -70,12 +68,9 @@ class CompetitionService: ObservableObject {
     func deleteRoom(roomID: String, completionHandler: @escaping () -> Void) {
         db.collection("RoomData").document(roomID).delete() { error in
             if let error = error {
-                // TODO: Alert Error to user
                 print("Cannot Remove Document: \(error)")
             }
             else {
-                // TODO: Alert Success to user
-                print("Successfully Removed Document")
                 self.requestRoomDatas()
             }
         }
@@ -103,12 +98,7 @@ class CompetitionService: ObservableObject {
             "kickedUsers": FieldValue.arrayUnion([userName])
         ]) { error in
             if let error = error {
-                // TODO: Alert Error to user
                 print("Cannot Kick User: \(error)")
-            }
-            else {
-                // TODO: Alert Success to user
-                print("Successfully Kicked User")
             }
         }
     }
@@ -118,8 +108,6 @@ class CompetitionService: ObservableObject {
         
         db.collection("RoomData").document(roomID).getDocument { documentSnapshot, error in
             guard let document = documentSnapshot else {
-                // TODO: Alert Error to user
-                print("Error Fetching Document: \(error!)")
                 return
             }
             
@@ -127,8 +115,6 @@ class CompetitionService: ObservableObject {
                   let jsonData = try? JSONSerialization.data(withJSONObject: data),
                   let roomData = try? JSONDecoder().decode(RoomData.self, from: jsonData)
             else {
-                // TODO: Alert Error to user
-                print("Cannot Decode")
                 return
             }
             

--- a/Git-Challenges/Let's Git it!/View/CompetitionEndedView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionEndedView.swift
@@ -1,0 +1,77 @@
+//
+//  CompetitionEndedView.swift
+//  Let's Git it!
+//
+//  Created by 권은빈 on 2022/03/11.
+//
+
+import SwiftUI
+
+struct CompetitionEndedView: View {
+    @Environment(\.presentationMode) private var presentationMode
+    @EnvironmentObject var competitionService: CompetitionService
+    @EnvironmentObject var competitionRoomViewModel: CompetitionRoomViewModel
+    @EnvironmentObject var colorThemeService: ColorThemeService
+    
+    var body: some View {
+        VStack {
+            roomDataSection
+            Divider()
+            descriptionLabel
+            rankList
+        }
+    }
+    
+    private var roomDataSection: some View {
+        VStack(spacing: 10) {
+            HStack {
+                Text("Start Date")
+                    .bold()
+                Spacer()
+                Text(competitionRoomViewModel.roomData.startDate)
+            }
+            HStack {
+                Text("End Date")
+                    .bold()
+                Spacer()
+                Text(competitionRoomViewModel.endDate().toString)
+            }
+            HStack {
+                Text("Goal")
+                    .bold()
+                Spacer()
+                Text("\(competitionRoomViewModel.roomData.goal)")
+                    .bold()
+            }
+        }
+        .padding([.leading, .trailing], 30)
+        .padding(.bottom, 10)
+    }
+    
+    private var descriptionLabel: some View {
+        HStack {
+            Text("Ranks")
+                .font(.system(size: 23, weight: .bold))
+                .bold()
+            Spacer()
+        }
+        .padding(.leading, 30)
+        .padding([.top, .bottom], 10)
+    }
+    
+    private var rankList: some View {
+        ScrollView {
+            ForEach(competitionRoomViewModel.rankedParticipants, id: \.self) { participant in
+                HStack {
+                    Text("\(competitionRoomViewModel.ranking(of: participant))")
+                    Text("\(participant)")
+                        .bold()
+                    Spacer(minLength: 0)
+                    Text("\(competitionRoomViewModel.participantStreak[participant] ?? 0)")
+                }
+                .padding([.leading, .trailing], 30)
+                .padding(.top, 10)
+            }
+        }
+    }
+}

--- a/Git-Challenges/Let's Git it!/View/CompetitionEndedView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionEndedView.swift
@@ -9,9 +9,7 @@ import SwiftUI
 
 struct CompetitionEndedView: View {
     @Environment(\.presentationMode) private var presentationMode
-    @EnvironmentObject var competitionService: CompetitionService
     @EnvironmentObject var competitionRoomViewModel: CompetitionRoomViewModel
-    @EnvironmentObject var colorThemeService: ColorThemeService
     
     var body: some View {
         VStack {

--- a/Git-Challenges/Let's Git it!/View/CompetitionEndedView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionEndedView.swift
@@ -50,7 +50,6 @@ struct CompetitionEndedView: View {
         HStack {
             Text("Ranks")
                 .font(.system(size: 23, weight: .bold))
-                .bold()
             Spacer()
         }
         .padding(.leading, 30)

--- a/Git-Challenges/Let's Git it!/View/CompetitionInProgressView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionInProgressView.swift
@@ -66,7 +66,6 @@ struct CompetitionInProgressView: View {
                 participantView(of: participant, percent)
                     .onTapGesture {
                         if isUserHost() {
-                            print("kick user")
                             alertType = .kickUserFromRoom
                             competitionRoomViewModel.userToKick = participant
                             showAlert.toggle()
@@ -79,7 +78,10 @@ struct CompetitionInProgressView: View {
     private func participantView(of name: String, _ percent: CGFloat) -> some View {
         VStack(spacing: 10) {
             participant(name: name)
-            progressBar(width: uiSize.width * widthRatio.progressBar, height: 10, percent: percent)
+            progressBar(
+                width: uiSize.width * widthRatio.progressBar,
+                height: 10, percent: percent
+            )
                 .padding()
         }
         .modifier(ParticipantCardModifier())
@@ -124,12 +126,14 @@ struct CompetitionInProgressView: View {
     }
     
     private func isUserHost() -> Bool {
-        let userID = UserDefaults.shared.string(forKey: "userId") ?? Auth.auth().currentUser?.uid ?? "none"
+        let userID = UserDefaults.shared.string(forKey: "userId") ??
+        Auth.auth().currentUser?.uid ?? "none"
         return userID == competitionRoomViewModel.host
     }
     
     private func isUser(_ participant: String) -> Bool {
-        let userID = UserDefaults.shared.string(forKey: "userId") ?? Auth.auth().currentUser?.uid ?? "none"
+        let userID = UserDefaults.shared.string(forKey: "userId") ??
+        Auth.auth().currentUser?.uid ?? "none"
         return userID == participant
     }
 }

--- a/Git-Challenges/Let's Git it!/View/CompetitionInProgressView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionInProgressView.swift
@@ -10,8 +10,6 @@ import SwiftUI
 import Firebase
 
 struct CompetitionInProgressView: View {
-    @Environment(\.presentationMode) private var presentationMode
-    @EnvironmentObject var competitionService: CompetitionService
     @EnvironmentObject var competitionRoomViewModel: CompetitionRoomViewModel
     @ObservedObject var colorThemeService: ColorThemeService = ColorThemeService()
     @Binding var showAlert: Bool

--- a/Git-Challenges/Let's Git it!/View/CompetitionInProgressView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionInProgressView.swift
@@ -80,7 +80,8 @@ struct CompetitionInProgressView: View {
             participant(name: name)
             progressBar(
                 width: uiSize.width * widthRatio.progressBar,
-                height: 10, percent: percent
+                height: 10,
+                percent: percent
             )
                 .padding()
         }

--- a/Git-Challenges/Let's Git it!/View/CompetitionInProgressView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionInProgressView.swift
@@ -1,0 +1,138 @@
+//
+//  CompetitionInProgressView.swift
+//  Let's Git it!
+//
+//  Created by 권은빈 on 2022/03/11.
+//
+
+import SwiftUI
+
+import Firebase
+
+struct CompetitionInProgressView: View {
+    @Environment(\.presentationMode) private var presentationMode
+    @EnvironmentObject var competitionService: CompetitionService
+    @EnvironmentObject var competitionRoomViewModel: CompetitionRoomViewModel
+    @ObservedObject var colorThemeService: ColorThemeService = ColorThemeService()
+    @Binding var showAlert: Bool
+    @Binding var alertType: RoomModificationAlertType
+    @State private var userNameToKick: String = ""
+
+    
+    var body: some View {
+        VStack {
+            roomDataSection
+            Divider()
+            descriptionLabel
+            memberList
+        }
+    }
+    
+    private var roomDataSection: some View {
+        VStack(spacing: 10) {
+            HStack {
+                Text("Start Date")
+                    .bold()
+                Spacer()
+                Text(competitionRoomViewModel.roomData.startDate)
+            }
+            HStack {
+                Text("Goal")
+                    .bold()
+                Spacer()
+                Text("\(competitionRoomViewModel.roomData.goal)")
+                    .bold()
+            }
+        }
+        .padding([.leading, .trailing], 30)
+        .padding(.bottom, 10)
+    }
+    
+    private var descriptionLabel: some View {
+        HStack {
+            Text("Members")
+                .bold()
+            Spacer()
+        }
+        .padding(.leading, 15)
+        .padding([.top, .bottom], 10)
+    }
+    
+    private var memberList: some View {
+        ScrollView {
+            ForEach(
+                competitionRoomViewModel.roomData.participants,
+                id: \.self
+            ) { participant in
+                let percent = competitionRoomViewModel.calculatePercentage(of: participant)
+                participantView(of: participant, percent)
+                    .onTapGesture {
+                        if isUserHost() {
+                            print("kick user")
+                            alertType = .kickUserFromRoom
+                            competitionRoomViewModel.userToKick = participant
+                            showAlert.toggle()
+                        }
+                    }
+            }
+        }
+    }
+    
+    private func participantView(of name: String, _ percent: CGFloat) -> some View {
+        VStack(spacing: 10) {
+            participant(name: name)
+            progressBar(width: uiSize.width * widthRatio.progressBar, height: 10, percent: percent)
+                .padding()
+        }
+        .modifier(ParticipantCardModifier())
+    }
+    
+    private func participant(name participant: String) -> some View {
+        return HStack {
+            Text("\(competitionRoomViewModel.ranking(of: participant))")
+            Text(participant)
+                .bold()
+            Spacer(minLength: 0)
+            Text("\(competitionRoomViewModel.participantStreak[participant] ?? 0)")
+        }
+        .padding([.leading, .trailing], 20)
+        .padding(.top, 15)
+        .buttonStyle(PlainButtonStyle())
+    }
+    
+    private func progressBar(width: CGFloat, height: CGFloat, percent: CGFloat) -> some View {
+        ZStack(alignment: .leading) {
+            Capsule()
+                .modifier(
+                    ProgressBarModifier(
+                        size: CGSize(
+                            width: width,
+                            height: height
+                        ),
+                        color: colorThemeService.themeColors[color.defaultGray.rawValue]
+                    )
+                )
+            Capsule()
+                .modifier(
+                    ProgressBarModifier(
+                        size: CGSize(
+                            width: width * percent,
+                            height: height
+                        ),
+                        color: colorThemeService.themeColors[color.progressBar.rawValue]
+                    )
+                )
+        }
+    }
+    
+    private func isUserHost() -> Bool {
+        let userID = UserDefaults.shared.string(forKey: "userId") ?? Auth.auth().currentUser?.uid ?? "none"
+        return userID == competitionRoomViewModel.host
+    }
+    
+    private func isUser(_ participant: String) -> Bool {
+        let userID = UserDefaults.shared.string(forKey: "userId") ?? Auth.auth().currentUser?.uid ?? "none"
+        return userID == participant
+    }
+}
+

--- a/Git-Challenges/Let's Git it!/View/CompetitionRoomView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionRoomView.swift
@@ -61,7 +61,7 @@ struct CompetitionRoomView: View {
                     title: Text(Message.kickUserFromRoomTitle),
                     message: Text(Message.kickUserFromRoomMessage),
                     primaryButton: .cancel(Text("Kick")) {
-                        competitionRoomViewModel.kickUserFromRoom(
+                        competitionRoomViewModel.kickUserAndUpdate(
                             competitionRoomViewModel.userToKick
                         )
                     },

--- a/Git-Challenges/Let's Git it!/View/CompetitionRoomView.swift
+++ b/Git-Challenges/Let's Git it!/View/CompetitionRoomView.swift
@@ -11,13 +11,12 @@ import Firebase
 
 struct CompetitionRoomView: View {
     @Environment(\.presentationMode) private var presentationMode
-    @EnvironmentObject var competitionService: CompetitionService
     @ObservedObject var competitionRoomViewModel: CompetitionRoomViewModel = CompetitionRoomViewModel()
-    @ObservedObject var colorThemeService: ColorThemeService = ColorThemeService()
+    @ObservedObject var competitionService: CompetitionService = CompetitionService()
     @State private var isConfiguring: Bool = true
     @State private var showAlert: Bool = false
     @State private var alertType: RoomModificationAlertType = .noAction
-    @State private var userNameToKick: String = ""
+
     
     init(of roomID: String) {
         competitionRoomViewModel.roomID = roomID
@@ -26,25 +25,13 @@ struct CompetitionRoomView: View {
     var body: some View {
         VStack {
             navigationBar
-            roomDataSection
-            Divider()
-            HStack {
-                Text("Members")
-                    .bold()
-                Spacer()
-            }
-            .padding(.leading, 30)
-            .padding([.top, .bottom], 10)
-            ScrollView {
-                ForEach(
-                    competitionRoomViewModel.roomData.participants,
-                    id: \.self
-                ) { participant in
-                    let percent = competitionRoomViewModel.calculatePercentage(of: participant)
-                    participantView(of: participant, percent)
-                }
+            if competitionRoomViewModel.isExpired() {
+                CompetitionEndedView()
+            } else {
+                CompetitionInProgressView(showAlert: $showAlert, alertType: $alertType)
             }
         }
+        .environmentObject(competitionRoomViewModel)
         .navigationBarHidden(true)
         .navigationBarBackButtonHidden(true)
         .overlay (
@@ -74,7 +61,9 @@ struct CompetitionRoomView: View {
                     title: Text(Message.kickUserFromRoomTitle),
                     message: Text(Message.kickUserFromRoomMessage),
                     primaryButton: .cancel(Text("Kick")) {
-                        competitionRoomViewModel.kickUserFromRoom(userNameToKick)
+                        competitionRoomViewModel.kickUserFromRoom(
+                            competitionRoomViewModel.userToKick
+                        )
                     },
                     secondaryButton: .default(Text("Cancel"))
                 )
@@ -139,102 +128,8 @@ struct CompetitionRoomView: View {
         .padding()
     }
     
-    private var roomDataSection: some View {
-        VStack(spacing: 10) {
-            HStack {
-                Text("Start Date")
-                    .bold()
-                Spacer()
-                Text(competitionRoomViewModel.roomData.startDate)
-            }
-            HStack {
-                Text("Max Streak")
-                    .bold()
-                Spacer()
-                Text("\(competitionRoomViewModel.maxStreak())")
-                    .bold()
-            }
-        }
-        .padding([.leading, .trailing], 30)
-        .padding(.bottom, 10)
-        .overlay(
-            ZStack {
-                if competitionRoomViewModel.isExpired() {
-                    Rectangle()
-                        .foregroundColor(Color(UIColor.systemBackground))
-                    Text("The competition is over.")
-                        .bold()
-                }
-            }
-        )
-    }
-    
-    private func participantView(of name: String, _ percent: CGFloat) -> some View {
-        VStack(spacing: 10) {
-            participant(name: name)
-            progressBar(width: uiSize.width * widthRatio.progressBar, height: 10, percent: percent)
-                .padding()
-        }
-        .modifier(ParticipantCardModifier())
-    }
-    
-    private func participant(name participant: String) -> some View {
-        return HStack {
-            Text(participant)
-                .bold()
-            Text("\(competitionRoomViewModel.ranking(of: participant))")
-            Spacer(minLength: 0)
-            Button {
-                if isUserHost() {
-                    alertType = .kickUserFromRoom
-                    userNameToKick = participant
-                    showAlert.toggle()
-                }
-            } label: {
-                Image(systemName: "x.circle")
-                    .foregroundColor(
-                        isUserHost() && !isUser(participant) ? .black : .clear
-                    )
-            }
-        }
-        .padding([.leading, .trailing], 20)
-        .padding(.top, 15)
-        .buttonStyle(PlainButtonStyle())
-    }
-    
-    private func progressBar(width: CGFloat, height: CGFloat, percent: CGFloat) -> some View {
-        ZStack(alignment: .leading) {
-            Capsule()
-                .modifier(
-                    ProgressBarModifier(
-                        size: CGSize(
-                            width: width,
-                            height: height
-                        ),
-                        color: colorThemeService.themeColors[color.defaultGray.rawValue]
-                    )
-                )
-            Capsule()
-                .modifier(
-                    ProgressBarModifier(
-                        size: CGSize(
-                            width: width * percent,
-                            height: height
-                        ),
-                        color: colorThemeService.themeColors[color.progressBar.rawValue]
-                    )
-                )
-        }
-    }
-    
     private func isUserHost() -> Bool {
         let userID = UserDefaults.shared.string(forKey: "userId") ?? Auth.auth().currentUser?.uid ?? "none"
         return userID == competitionRoomViewModel.host
     }
-    
-    private func isUser(_ participant: String) -> Bool {
-        let userID = UserDefaults.shared.string(forKey: "userId") ?? Auth.auth().currentUser?.uid ?? "none"
-        return userID == participant
-    }
 }
-

--- a/Git-Challenges/Let's Git it!/ViewModel/CompetitionRoomViewModel.swift
+++ b/Git-Challenges/Let's Git it!/ViewModel/CompetitionRoomViewModel.swift
@@ -18,7 +18,7 @@ class CompetitionRoomViewModel: ObservableObject {
     var host: String = ""
     var userToKick: String = ""
     
-    func kickUserFromRoom(_ userNameToKick: String) {
+    func kickUserAndUpdate(_ userNameToKick: String) {
         CompetitionService.kickUserFromRoom(
             roomID: self.roomData.id,
             userName: userNameToKick

--- a/Git-Challenges/Let's Git it!/ViewModel/CompetitionRoomViewModel.swift
+++ b/Git-Challenges/Let's Git it!/ViewModel/CompetitionRoomViewModel.swift
@@ -10,13 +10,13 @@ import SwiftUI
 import SwiftSoup
 
 class CompetitionRoomViewModel: ObservableObject {
-    // TODO: Users' git streak count and return the values
-    
     @Published var roomData: RoomData = RoomData()
     @Published var participantStreak: [String: Int] = [:]
     @Published var ranks: [String: Int] = [:]
+    @Published var rankedParticipants: [String] = [String]()
     var roomID: String = ""
     var host: String = ""
+    var userToKick: String = ""
     
     func kickUserFromRoom(_ userNameToKick: String) {
         CompetitionService.kickUserFromRoom(
@@ -30,16 +30,13 @@ class CompetitionRoomViewModel: ObservableObject {
     
     func calculateParticipantStreak() {
         if roomData.participants.isEmpty {
-            // Error: no participants
             return
         }
         
         for participant in roomData.participants {
-            let commits = getCommitData(of: participant)
+            let commits = commitData(of: participant)
             let streak = calculateStreak(with: commits)
             participantStreak[participant] = streak
-            // if particiapantStreak[participant] >= goal, Alert to user
-            print("\(participant): \(streak)")
         }
     }
     
@@ -47,7 +44,6 @@ class CompetitionRoomViewModel: ObservableObject {
         let goal = roomData.goal
         guard let streak = participantStreak[participant]
         else {
-            // Alert to user that there's no valid participant
             return 0
         }
         
@@ -70,20 +66,34 @@ class CompetitionRoomViewModel: ObservableObject {
         return currentStreak + 1
     }
     
+    func endDate() -> Date {
+        let startDate = roomData.startDate.toDate() ?? Date()
+        let daysAfter = roomData.goal - 1
+        
+        guard let endDate = Calendar.current.date(
+            byAdding: DateComponents(day: daysAfter),
+            to: startDate
+        )
+        else { return Date() }
+        return endDate
+    }
+    
     func isExpired() -> Bool {
-        return roomData.goal < maxStreak()
+        return endDate() < Date()
     }
     
     func calculateRanking() {
         let sortedStreak = Set(participantStreak.values).sorted { $0 > $1 }
         var ranks = [String: Int]()
+        var rankedParticipants = [String]()
         var rank = 0
         var sameRankCount = 0
         
         for streak in sortedStreak {
             for (participant, participantStreak) in participantStreak {
                 if streak == participantStreak {
-                    ranks[participant] = rank
+                    rankedParticipants.append(participant)
+                    ranks[participant, default: 0] += rank
                     sameRankCount += 1
                 }
             }
@@ -92,6 +102,7 @@ class CompetitionRoomViewModel: ObservableObject {
         }
         
         self.ranks = ranks
+        self.rankedParticipants = rankedParticipants
     }
     
     func ranking(of participant: String) -> String {
@@ -103,7 +114,7 @@ class CompetitionRoomViewModel: ObservableObject {
         return participantRank <= 2 ? rankEmoji[participantRank] : ""
     }
     
-    private func getCommitData(of userID: String) -> [Commit] {
+    private func commitData(of userID: String) -> [Commit] {
         var commits: [Commit] = [Commit]()
         
         let baseURL: String = "http://github.com/users/\(userID)/contributions"
@@ -125,7 +136,7 @@ class CompetitionRoomViewModel: ObservableObject {
                 })
                 .filter{ $0.0.isEmpty == false }
                 .compactMap({ (dateString, levelString) -> Commit in
-                    let date = dateString.toDate() ?? Date() // 여기서 시간
+                    let date = dateString.toDate() ?? Date()
                     let level = Int(levelString) ?? 0
                     
                     return Commit(date: date, level: level)
@@ -142,14 +153,20 @@ class CompetitionRoomViewModel: ObservableObject {
     }
     
     private func calculateStreak(with commits: [Commit]) -> Int {
-        let today = commits.count - 1
-        let yesterday = commits.count - 2
+        var today = commits.count - 1
+        var yesterday = today - 1
+        let endDate = self.endDate()
         var streakStartDate: Date? = nil
         var streak = 0
         
         if commits.isEmpty {
             return 0
         }
+        
+        while commits[today].date > endDate {
+            today -= 1
+        }
+        yesterday = today - 1
         
         if commits[yesterday].level == 0 && commits[today].level == 0 {
             return 0
@@ -160,22 +177,12 @@ class CompetitionRoomViewModel: ObservableObject {
                 streakStartDate = commits[day].date
                 streak += 1
             }
-            if (streakStartDate != nil && commits[day].level == 0) {
+            if roomData.startDate == commits[day].date.toString ||
+                (streakStartDate != nil && commits[day].level == 0) {
                 break
             }
         }
         
         return streak
-    }
-    
-    private func hasUserCommittedToday(_ todayCommitData: Commit?) -> Bool {
-        guard let todayCommitData = todayCommitData
-        else {
-            return false
-        }
-        if todayCommitData.date.isToday && todayCommitData.level > 0 {
-            return true
-        }
-        return false
     }
 }


### PR DESCRIPTION
## 반영 내용
#89 

### CompetitionRoomView 나누기
- CompetitionInProgressView와 CompetitionEndedView로 분리
- navigationBar, alert 재사용

### Streak계산 로직 수정
- 잘못됐던 streak 계산 로직 수정
- 기존: 오늘을 기준으로 startDate까지의 streak 계산
- 변경: endDate를 기준으로 startDate까지의 streak 계산

### 기타 확인사항
- 뷰 넘어가면서 계산해야될 것들이 많아서 그런지 속도가 느립니다. 2~3명까진 괜찮은데 6명 되는 순간 꽤나 걸려요. 추후 최적화 필요..!!