### PR TITLE
[feat] Add Alert when user tapped logout button in settings view #109

### DIFF
--- a/Git-Challenges/Git-Challenges.xcodeproj/project.pbxproj
+++ b/Git-Challenges/Git-Challenges.xcodeproj/project.pbxproj
@@ -138,7 +138,7 @@
 		73528DF727997183005DF67C /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		735AA3BD27914950000E4E8C /* ContributionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributionView.swift; sourceTree = "<group>"; };
 		735AA3C427916A16000E4E8C /* UserInfoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoService.swift; sourceTree = "<group>"; };
-		73710D9A279009F3009EBA62 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		73710D9A279009F3009EBA62 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../GoogleService-Info.plist"; sourceTree = "<group>"; };
 		73710DAB279018A6009EBA62 /* CardModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardModifier.swift; sourceTree = "<group>"; };
 		73710DAD27902ED2009EBA62 /* NameCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameCardView.swift; sourceTree = "<group>"; };
 		73751ED5279D6A76006A8F94 /* ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };

--- a/Git-Challenges/Let's Git it!/Subview/NotificationCell.swift
+++ b/Git-Challenges/Let's Git it!/Subview/NotificationCell.swift
@@ -26,5 +26,26 @@ struct NotificationCell: View {
             }
         }
         .modifier(SettingCellModifier())
+        .alert(isPresented: $notificationManager.isAlertOccurred) {
+            Alert(
+                title: Text(Message.notiDeniedInSettingsTitle),
+                message: Text(Message.notiDeniedInSettingsMessage),
+                primaryButton: .default(Text("Cancel"), action: {
+                    notificationManager.isNotiOn = false
+                }),
+                secondaryButton: .cancel(Text("Go to Settings"), action: {
+                    notificationManager.isNotiOn = false
+                    openSettings()
+                }))
+        }
+    }
+    
+    private func openSettings() {
+        if let bundle = Bundle.main.bundleIdentifier,
+           let settings = URL(string: UIApplication.openSettingsURLString + bundle) {
+            if UIApplication.shared.canOpenURL(settings) {
+                UIApplication.shared.open(settings)
+            }
+        }
     }
 }

--- a/Git-Challenges/Let's Git it!/Util/Constants.swift
+++ b/Git-Challenges/Let's Git it!/Util/Constants.swift
@@ -43,11 +43,6 @@ enum RoomModificationAlertType {
     case leaveRoom
 }
 
-enum SettingViewAlertType {
-    case logout
-    case notification
-}
-
 enum widthRatio {
     static let card: CGFloat = 0.888
     static let badge: CGFloat = 1

--- a/Git-Challenges/Let's Git it!/Util/Constants.swift
+++ b/Git-Challenges/Let's Git it!/Util/Constants.swift
@@ -25,6 +25,7 @@ enum Message {
     static let deleteRoomMessage: String = "This cannot be restored.\nReally want to delete the room?"
     static let leaveRoomTitle: String = "Leave this room"
     static let leaveRoomMessage: String = "This cannot be restored.\nReally want to leave the room?"
+    static let logoutTitle: String = "Are you sure you want to log out?"
 }
 
 enum JoinErrorMessage {
@@ -40,6 +41,11 @@ enum RoomModificationAlertType {
     case deleteRoom
     case noAction
     case leaveRoom
+}
+
+enum SettingViewAlertType {
+    case logout
+    case notification
 }
 
 enum widthRatio {

--- a/Git-Challenges/Let's Git it!/View/SettingView.swift
+++ b/Git-Challenges/Let's Git it!/View/SettingView.swift
@@ -13,6 +13,7 @@ struct SettingView: View {
     @ObservedObject private var notificationManager: NotificationManager = NotificationManager()
     @Environment(\.loginStatus) var loging
     @Environment(\.presentationMode) var presentationMode
+    @State private var showAlert: Bool = false
     
     var body: some View {
         VStack {
@@ -21,18 +22,6 @@ struct SettingView: View {
             footer
         }
         .navigationBarTitle("", displayMode: .inline)
-        .alert(isPresented: $notificationManager.isAlertOccurred) {
-            Alert(
-                title: Text(Message.notiDeniedInSettingsTitle),
-                message: Text(Message.notiDeniedInSettingsMessage),
-                primaryButton: .default(Text("Cancel"), action: {
-                    notificationManager.isNotiOn = false
-                }),
-                secondaryButton: .cancel(Text("Go to Settings"), action: {
-                    notificationManager.isNotiOn = false
-                    openSettings()
-                }))
-        }
     }
     
     private var settings: some View {
@@ -64,15 +53,6 @@ struct SettingView: View {
         }
     }
     
-    private func openSettings() {
-        if let bundle = Bundle.main.bundleIdentifier,
-           let settings = URL(string: UIApplication.openSettingsURLString + bundle) {
-            if UIApplication.shared.canOpenURL(settings) {
-                UIApplication.shared.open(settings)
-            }
-        }
-    }
-    
     private func openGithubRepo() {
         if let url = URL(string: URLString.gitHubRepo) {
             if UIApplication.shared.canOpenURL(url) {
@@ -88,21 +68,34 @@ struct SettingView: View {
     
     private func logoutButton() -> some View {
         Button {
-            do {
-                try Auth.auth().signOut()
-                UserDefaults.shared.removeObject(forKey: "isLogin")
-                UserDefaults.shared.removeObject(forKey: "userId")
-                UserDefaults.shared.removeObject(forKey: "userNotiTime")
-                self.notificationManager.isNotiOn = false
-                self.presentationMode.wrappedValue.dismiss()
-                self.loging.wrappedValue = false
-            }
-            catch let signOutError as NSError {
-                print("Error signing out: ", signOutError)
-            }
+            self.showAlert = true
         } label: {
             Text("Log Out")
                 .modifier(LogoutButtonText())
+        }
+        .alert(isPresented: $showAlert) {
+            Alert(
+                title: Text(Message.logoutTitle),
+                primaryButton: .default(Text("Cancel")),
+                secondaryButton: .cancel(Text("Log out"), action: {
+                    logout()
+                })
+            )
+        }
+    }
+    
+    private func logout() {
+        do {
+            try Auth.auth().signOut()
+            UserDefaults.shared.removeObject(forKey: "isLogin")
+            UserDefaults.shared.removeObject(forKey: "userId")
+            UserDefaults.shared.removeObject(forKey: "userNotiTime")
+            self.notificationManager.isNotiOn = false
+            self.presentationMode.wrappedValue.dismiss()
+            self.loging.wrappedValue = false
+        }
+        catch let signOutError as NSError {
+            print("Error signing out: ", signOutError)
         }
     }
 }


### PR DESCRIPTION
### 반영 내용
issue #109 

### SettingView
- 기존 SettingView에 붙어 있던 로컬 노티피케이션 관련 알림창을 NotificationCell로 이동
    - SwiftUI에서 하나의 뷰에 두 개 이상의 alert 추가 불가하기 때문
- logoutButton에 로그아웃 관련 알림창 추가
