### PR TITLE
[fix] change query for getting commit data

### DIFF
--- a/Git-Challenges/Let's Git it!/Service/UserInfoService.swift
+++ b/Git-Challenges/Let's Git it!/Service/UserInfoService.swift
@@ -76,7 +76,7 @@ class UserInfoService: ObservableObject {
             do {
                 let html = try String(contentsOf: url, encoding: .utf8)
                 let parsedHtml = try SwiftSoup.parse(html)
-                let dailyContribution = try parsedHtml.select("rect")
+                let dailyContribution = try parsedHtml.select("td")
                 
                 commits = dailyContribution
                     .compactMap({ element -> (String, String) in


### PR DESCRIPTION
## 🚨 문제
- `UserInfoService` 클래스 내의 `getCommitData()` 메서드를 통해 contribution 정보 호출 시 선택해야 하는 HTML 태그 변경
- 태그 변경으로 인해 잘못된 태그가 선택되어 `commits` 내의 요소가 존재하지 않게 됨
- 요소가 없는 배열인 `commits`에 강제 언래핑을 통해 데이터를 접근하는 과정에서 오류가 발생하여 앱이 실행되지 않음

## ⚒️ 해결
- 태그 변경에 따라 select할 query 변경 (`rect` -> `td`)
- 정상 작동 확인! 😎
![Simulator Screen Recording - iPhone 14 Pro - 2023-07-27 at 16 17 11](https://github.com/42Caterpie/Lets-Git-It-iOS/assets/71758542/58d44a69-2411-4996-83d0-9c4699adf2a8)

